### PR TITLE
Update rust-setup.md

### DIFF
--- a/docs/rust-setup.md
+++ b/docs/rust-setup.md
@@ -25,7 +25,7 @@ Use a terminal shell to execute the following commands:
 ```bash
 sudo apt update
 # May prompt for location information
-sudo apt install -y git clang curl libssl-dev llvm libudev-dev
+sudo apt install -y git clang curl libssl-dev llvm libudev-dev cmake make
 ```
 
 ### Arch Linux


### PR DESCRIPTION
It was not possible to complete compiling without having the `cmake` and/or `make` packages installed.